### PR TITLE
fix: remove pesto from code execution provider

### DIFF
--- a/BotNet.Services/Pesto/Models/Language.cs
+++ b/BotNet.Services/Pesto/Models/Language.cs
@@ -18,8 +18,8 @@ public enum Language {
 	Go = 5,
 	[EnumMember(Value = "Java")]
 	Java = 6,
-	[EnumMember(Value = "JavaScript")]
-	JavaScript = 7,
+	[EnumMember(Value = "Javascript")]
+	Javascript = 7,
 	[EnumMember(Value = "Julia")]
 	Julia = 8,
 	[EnumMember(Value = "Lua")]
@@ -46,7 +46,7 @@ public static class LanguageExtensions {
 			Language.DotNet => ".NET",
 			Language.Go => "Go",
 			Language.Java => "Java",
-			Language.JavaScript => "JavaScript",
+			Language.Javascript => "JavaScript",
 			Language.Julia => "Julia",
 			Language.Lua => "Lua",
 			Language.PHP => "PHP",


### PR DESCRIPTION
This PR aims to remove Pesto from the list of code execution providers on Botnet. In hope that people would be able to continue using the code execution command through Piston (if it's also not broken).

It seems like every HTTP call that was made from fly.io to Teknum's Contabo server won't successfully return in any way -- not just for Pesto, but also for Polarite and Graphene. It's weird. The solution on the [bot](https://github.com/teknologi-umum/bot) was to move the instance from fly.io to Teknum's Contabo Server.