### PR TITLE
chore(ai): increase group rate limit to 4 msgs per 60 minutes

### DIFF
--- a/BotNet.CommandHandlers/AI/RateLimit/AIRateLimiters.cs
+++ b/BotNet.CommandHandlers/AI/RateLimit/AIRateLimiters.cs
@@ -2,6 +2,6 @@
 
 namespace BotNet.CommandHandlers.AI.RateLimit {
 	internal static class AIRateLimiters {
-		internal static readonly RateLimiter GROUP_CHAT_RATE_LIMITER = RateLimiter.PerUserPerChat(4, TimeSpan.FromMinutes(15));
+		internal static readonly RateLimiter GROUP_CHAT_RATE_LIMITER = RateLimiter.PerUserPerChat(4, TimeSpan.FromMinutes(60));
 	}
 }


### PR DESCRIPTION
With the current rate limit scheme, the group is too noisy of AI chats and people don't seem to interact with other humans anymore, they'll just prefer to interact with AI bots.

This PR rate limits to 4 messages per 60 minutes, that means 4 messages of OpenAI and 4 messages of Gemini per hour. 