### PR TITLE
Overhaul /map command with advanced features

### DIFF
--- a/BotNet.Services/GoogleMap/GeoCode.cs
+++ b/BotNet.Services/GoogleMap/GeoCode.cs
@@ -6,6 +6,8 @@ using Microsoft.Extensions.Options;
 using BotNet.Services.GoogleMap.Models;
 using System.IO;
 using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace BotNet.Services.GoogleMap {
 
@@ -18,8 +20,147 @@ namespace BotNet.Services.GoogleMap {
 	) {
 		private readonly string? _apiKey = options.Value.ApiKey;
 		private const string UriTemplate = "https://maps.googleapis.com/maps/api/geocode/json";
+		
+		// Monas coordinates: 6°10′31.4″S 106°49′37.7″E = -6.175389, 106.827139
+		private const double MonasLatitude = -6.175389;
+		private const double MonasLongitude = 106.827139;
+
+		// Bounding box around Jakarta (roughly 50km radius)
+		// Southwest: -6.37, 106.65
+		// Northeast: -5.98, 107.00
+		private const string JakartaBounds = "-6.37,106.65|-5.98,107.00";
+
+		// Bounding box around Jabodetabek (Jakarta metropolitan area)
+		// Southwest: -6.73, 106.48 (includes Bogor, Depok, Tangerang, Bekasi)
+		// Northeast: -5.87, 107.18
+		private const string JabodetabekBounds = "-6.73,106.48|-5.87,107.18";
+
+		// Bounding box around Java and Bali
+		// Southwest: -8.78, 105.15 (Southern Java)
+		// Northeast: -5.50, 116.35 (Eastern Bali)
+		private const string JavaBaliBounds = "-8.78,105.15|-5.50,116.35";
+
+		// Bounding box around Indonesia
+		// Southwest: -11.00, 95.00 (Southern Java/Bali)
+		// Northeast: 6.00, 141.00 (Northern Papua)
+		private const string IndonesiaBounds = "-11.00,95.00|6.00,141.00";
 
 		/// <summary>
+		/// Search for places and return all results sorted by distance from Jakarta (Monas)
+		/// Uses fallback strategy: Jakarta -> Jabodetabek -> Java+Bali -> Indonesia -> Worldwide
+		/// </summary>
+		/// <param name="place">Place or address that you want to search</param>
+		/// <returns>List of results sorted by distance from Jakarta</returns>
+		/// <exception cref="HttpRequestException"></exception>
+		public async Task<List<Result>> SearchPlacesAsync(string? place) {
+			if (string.IsNullOrEmpty(place)) {
+				throw new HttpRequestException("Invalid place");
+			}
+
+			if (string.IsNullOrEmpty(_apiKey)) {
+				throw new HttpRequestException("Api key is needed");
+			}
+
+			// Try Jakarta bounds first
+			List<Result>? results = await SearchWithBoundsAsync(place, JakartaBounds);
+			if (results != null && results.Count > 0) {
+				return results;
+			}
+
+			// Fallback to Jabodetabek (Greater Jakarta)
+			results = await SearchWithBoundsAsync(place, JabodetabekBounds);
+			if (results != null && results.Count > 0) {
+				return results;
+			}
+
+			// Fallback to Java + Bali
+			results = await SearchWithBoundsAsync(place, JavaBaliBounds);
+			if (results != null && results.Count > 0) {
+				return results;
+			}
+
+			// Fallback to Indonesia bounds
+			results = await SearchWithBoundsAsync(place, IndonesiaBounds);
+			if (results != null && results.Count > 0) {
+				return results;
+			}
+
+			// Fallback to worldwide search
+			results = await SearchWithBoundsAsync(place, null);
+			if (results != null && results.Count > 0) {
+				return results;
+			}
+
+			throw new HttpRequestException("No Result.");
+		}
+
+		/// <summary>
+		/// Search with optional bounds parameter
+		/// </summary>
+		/// <param name="place">Place or address to search</param>
+		/// <param name="bounds">Optional bounds parameter (southwest|northeast)</param>
+		/// <returns>List of results sorted by distance from Jakarta, or null if search failed</returns>
+		private async Task<List<Result>?> SearchWithBoundsAsync(string place, string? bounds) {
+			string url = string.IsNullOrEmpty(bounds)
+				? $"{UriTemplate}?address={place}&key={_apiKey}"
+				: $"{UriTemplate}?address={place}&bounds={bounds}&key={_apiKey}";
+
+			Uri uri = new(url);
+			HttpResponseMessage response = await httpClient.GetAsync(uri.AbsoluteUri);
+
+			if (response is not { StatusCode: HttpStatusCode.OK, Content.Headers.ContentType.MediaType: string contentType }) {
+				return null;
+			}
+
+			if (response.Content is null || contentType is not "application/json") {
+				return null;
+			}
+
+			Stream bodyContent = await response.Content!.ReadAsStreamAsync();
+
+			Response? body = await JsonSerializer.DeserializeAsync<Response>(bodyContent, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+			if (body is null || body.Status is not "OK" || body.Results is null || body.Results.Count == 0) {
+				return null;
+			}
+
+			// Sort results by distance from Monas (Jakarta center)
+			List<Result> sortedResults = body.Results
+				.Where(r => r.Geometry?.Location != null)
+				.OrderBy(r => CalculateDistance(
+					MonasLatitude, 
+					MonasLongitude, 
+					r.Geometry!.Location!.Lat, 
+					r.Geometry!.Location!.Lng
+				))
+				.ToList();
+
+			return sortedResults;
+		}
+
+		/// <summary>
+		/// Calculate distance between two coordinates using Haversine formula
+		/// </summary>
+		/// <returns>Distance in kilometers</returns>
+		private static double CalculateDistance(double lat1, double lon1, double lat2, double lon2) {
+			const double R = 6371; // Earth's radius in kilometers
+			double dLat = ToRadians(lat2 - lat1);
+			double dLon = ToRadians(lon2 - lon1);
+			
+			double a = Math.Sin(dLat / 2) * Math.Sin(dLat / 2) +
+					   Math.Cos(ToRadians(lat1)) * Math.Cos(ToRadians(lat2)) *
+					   Math.Sin(dLon / 2) * Math.Sin(dLon / 2);
+			
+			double c = 2 * Math.Atan2(Math.Sqrt(a), Math.Sqrt(1 - a));
+			return R * c;
+		}
+
+		private static double ToRadians(double degrees) {
+			return degrees * Math.PI / 180.0;
+		}
+
+		/// <summary>
+		/// Legacy method for backward compatibility
 		/// The response of this api call is consist of 2 parts.
 		/// Array of "results" and string of "status"
 		/// 
@@ -30,43 +171,9 @@ namespace BotNet.Services.GoogleMap {
 		/// <returns>strings of coordinates</returns>
 		/// <exception cref="HttpRequestException"></exception>
 		public async Task<(double Lat, double Lng)> SearchPlaceAsync(string? place) {
-			if (string.IsNullOrEmpty(place)) {
-				throw new HttpRequestException("Invalid place");
-			}
-
-			if (string.IsNullOrEmpty(_apiKey)) {
-				throw new HttpRequestException("Api key is needed");
-			}
-
-			Uri uri = new($"{UriTemplate}?address={place}&key={_apiKey}");
-			HttpResponseMessage response = await httpClient.GetAsync(uri.AbsoluteUri);
-
-			if (response is not { StatusCode: HttpStatusCode.OK, Content.Headers.ContentType.MediaType: string contentType }) {
-				throw new HttpRequestException("Unable to find location.");
-			}
-
-			if (response.Content is null && contentType is not "application/json") {
-				throw new HttpRequestException("Failed to parse result.");
-			}
-
-			Stream bodyContent = await response.Content!.ReadAsStreamAsync();
-
-			Response? body = await JsonSerializer.DeserializeAsync<Response>(bodyContent, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-
-			if (body is null) {
-				throw new HttpRequestException("Failed to parse result.");
-			}
-
-			if (body.Status is not "OK") {
-				throw new HttpRequestException("Unable to find location.");
-			}
-
-			if (body.Results!.Count <= 0) {
-				throw new HttpRequestException("No Result.");
-			}
-
-			Result result = body.Results[0];
-
+			List<Result> results = await SearchPlacesAsync(place);
+			Result result = results[0];
+			
 			double lat = result.Geometry!.Location!.Lat;
 			double lng = result.Geometry!.Location!.Lng;
 

--- a/BotNet.Services/GoogleMap/Models/Geometry.cs
+++ b/BotNet.Services/GoogleMap/Models/Geometry.cs
@@ -6,9 +6,16 @@
 		// ReSharper disable once InconsistentNaming
 		public string? Location_Type { get; set; }
 
+		public Viewport? Viewport { get; set; }
+
 		public class Coordinate {
 			public double Lat { get; set; }
 			public double Lng { get; set; }
 		}
+	}
+
+	public class Viewport {
+		public Geometry.Coordinate? Northeast { get; set; }
+		public Geometry.Coordinate? Southwest { get; set; }
 	}
 }

--- a/BotNet.Services/GoogleMap/Models/Result.cs
+++ b/BotNet.Services/GoogleMap/Models/Result.cs
@@ -5,5 +5,11 @@
 		public string? Formatted_Address { get; set; }
 
 		public Geometry? Geometry { get; set; }
+
+		// ReSharper disable once InconsistentNaming
+		public string[]? Types { get; set; }
+
+		// ReSharper disable once InconsistentNaming
+		public string? Place_Id { get; set; }
 	}
 }

--- a/BotNet.Services/GoogleMap/StaticMap.cs
+++ b/BotNet.Services/GoogleMap/StaticMap.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Microsoft.Extensions.Options;
+using BotNet.Services.GoogleMap.Models;
 
 namespace BotNet.Services.GoogleMap {
 
@@ -11,13 +12,74 @@ namespace BotNet.Services.GoogleMap {
 	) {
 		private readonly string? _apiKey = options.Value.ApiKey;
 		private const string MapPosition = "center";
-		private const int Zoom = 13;
 		private const string Size = "600x300";
 		private const string Marker = "color:red";
 		private const string UriTemplate = "https://maps.googleapis.com/maps/api/staticmap";
 
 		/// <summary>
-		/// Get static map image from google map api
+		/// Calculate appropriate zoom level based on viewport bounding box
+		/// </summary>
+		/// <param name="viewport">Viewport from geocoding result</param>
+		/// <returns>Zoom level (1-20)</returns>
+		public static int CalculateZoomLevel(Viewport? viewport) {
+			if (viewport?.Northeast == null || viewport.Southwest == null) {
+				return 13; // Default zoom
+			}
+
+			// Calculate the span of the viewport
+			double latSpan = Math.Abs(viewport.Northeast.Lat - viewport.Southwest.Lat);
+			double lngSpan = Math.Abs(viewport.Northeast.Lng - viewport.Southwest.Lng);
+			double maxSpan = Math.Max(latSpan, lngSpan);
+
+			// Calculate zoom level based on span
+			// Zoom levels: 1 (world) to 20 (buildings)
+			// Each zoom level roughly doubles the detail
+			if (maxSpan >= 180) return 1;  // World
+			if (maxSpan >= 90) return 2;
+			if (maxSpan >= 45) return 3;
+			if (maxSpan >= 22.5) return 4;
+			if (maxSpan >= 11.25) return 5; // Large region
+			if (maxSpan >= 5.625) return 6;
+			if (maxSpan >= 2.813) return 7;
+			if (maxSpan >= 1.406) return 8;
+			if (maxSpan >= 0.703) return 9;
+			if (maxSpan >= 0.352) return 10; // City
+			if (maxSpan >= 0.176) return 11;
+			if (maxSpan >= 0.088) return 12;
+			if (maxSpan >= 0.044) return 13; // District
+			if (maxSpan >= 0.022) return 14;
+			if (maxSpan >= 0.011) return 15; // Streets
+			if (maxSpan >= 0.005) return 16;
+			if (maxSpan >= 0.0025) return 17;
+			if (maxSpan >= 0.00125) return 18;
+			if (maxSpan >= 0.000625) return 19;
+			return 20; // Buildings
+		}
+
+		/// <summary>
+		/// Get static map image URL with custom zoom level
+		/// </summary>
+		/// <param name="lat">Latitude</param>
+		/// <param name="lng">Longitude</param>
+		/// <param name="zoom">Zoom level (1-20)</param>
+		/// <param name="markerLabel">Optional marker label</param>
+		/// <returns>string of url</returns>
+		public string GetMapUrl(double lat, double lng, int zoom, string? markerLabel = null) {
+			if (string.IsNullOrEmpty(_apiKey)) {
+				return "Api key is needed";
+			}
+
+			string marker = markerLabel != null 
+				? $"{Marker}|label:{markerLabel}|{lat},{lng}"
+				: $"{Marker}|{lat},{lng}";
+
+			Uri uri = new($"{UriTemplate}?{MapPosition}={lat},{lng}&zoom={zoom}&size={Size}&markers={marker}&key={_apiKey}");
+
+			return uri.ToString();
+		}
+
+		/// <summary>
+		/// Get static map image from google map api (legacy method)
 		/// </summary>
 		/// <param name="place">Place or address that you want to search</param>
 		/// <returns>string of url</returns>
@@ -30,7 +92,7 @@ namespace BotNet.Services.GoogleMap {
 				return "Api key is needed";
 			}
 
-			Uri uri = new($"{UriTemplate}?{MapPosition}={place}&zoom={Zoom}&size={Size}&markers={Marker}|{place}&key={_apiKey}");
+			Uri uri = new($"{UriTemplate}?{MapPosition}={place}&zoom=13&size={Size}&markers={Marker}|{place}&key={_apiKey}");
 
 			return uri.ToString();
 		}


### PR DESCRIPTION
- Closes #92
- Closes #93
- Closes #94

Major improvements:
- Rich place information: Shows searched name, formatted address, place types, coordinates
- Smart zoom level: Calculates from viewport bounding box (1-20), defaults to 13
- Cascading geographic search with 5 fallback levels:
  1. Jakarta (~50km radius around Monas)
  2. Jabodetabek (Greater Jakarta metropolitan area)
  3. Java + Bali
  4. Indonesia (entire archipelago)
  5. Worldwide
- Multiple results display: Shows up to 3 other matching places with links
- Haversine distance calculation: Sorts all results by proximity to Monas

New APIs:
- GeoCode.SearchPlacesAsync(): Returns all results with cascading search
- GeoCode.SearchWithBoundsAsync(): Internal helper for bounded searches
- StaticMap.CalculateZoomLevel(): Determines zoom from viewport span (1-20)
- StaticMap.GetMapUrl(): Generates URL with custom coordinates and zoom

Model enhancements:
- Result: Added Types[] and Place_Id fields
- Geometry: Added Viewport with Northeast/Southwest bounds
- Viewport: New class for bounding box data

The cascading search prioritizes Indonesian locations (especially Jakarta) while still allowing worldwide queries. Each level tries progressively larger geographic bounds until results are found.

Reference point: Monas (-6.175389, 106.827139)